### PR TITLE
feat!: Implement middleware system for modifying requests/responses

### DIFF
--- a/src/adapters/fetch-network-adapter.ts
+++ b/src/adapters/fetch-network-adapter.ts
@@ -1,5 +1,4 @@
 import { NetworkAdapter, Request } from './network-adapter.js'
-import { joinCookies } from '../cookies.js'
 
 export function fetchNetworkAdapter (): NetworkAdapter {
   return {
@@ -7,7 +6,7 @@ export function fetchNetworkAdapter (): NetworkAdapter {
       const fetchResponse = await fetch(request.url, {
         method: request.method,
         headers: buildHeaders(request),
-        body: transformRequestBody(request.data)
+        body: transformRequestBody(request.body)
       })
 
       return {
@@ -19,19 +18,11 @@ export function fetchNetworkAdapter (): NetworkAdapter {
   }
 }
 
-function buildHeaders (request: Request): Record<string, string> {
-  const headers = {}
+function buildHeaders (request: Request): Headers {
+  const headers = new Headers(request.headers)
 
-  if (request.data != null) {
-    Object.assign(headers, {
-      'Content-Type': 'application/json'
-    })
-  }
-
-  if (request.cookies != null && request.cookies.length > 0) {
-    Object.assign(headers, {
-      Cookie: joinCookies(request.cookies)
-    })
+  if (request.body != null && !headers.has('content-type')) {
+    headers.set('content-type', 'application/json')
   }
 
   return headers

--- a/src/adapters/network-adapter.ts
+++ b/src/adapters/network-adapter.ts
@@ -1,13 +1,11 @@
-import { Cookie } from '../cookies.js'
-
 export type HttpVerb = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE'
 export type CaseInsensitiveHttpVerb = Uppercase<HttpVerb> | Lowercase<HttpVerb>
 
 export interface Request {
   url: URL
   method: CaseInsensitiveHttpVerb
-  data?: any | undefined
-  cookies?: readonly Cookie[]
+  body?: any | undefined
+  headers: Headers
 }
 
 export interface Response {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,17 +1,28 @@
 import { client, HttpClient } from './client.js'
-import { voidCookieStore } from './stores/void-cookie-store.js'
 import { memoryCookieStore } from './stores/memory-cookie-store.js'
 import { fetchNetworkAdapter } from './adapters/fetch-network-adapter.js'
+import { Cookie, cookieMiddleware } from './cookies.js'
 
-export { HttpVerb, CaseInsensitiveHttpVerb } from './adapters/network-adapter.js'
-export { HttpClient, RequestMethod, RequestMethodWithData } from './client.js'
+export { HttpVerb, CaseInsensitiveHttpVerb, Request, Response } from './adapters/network-adapter.js'
+export { HttpClient, RequestMethod, RequestMethodWithData, Middleware } from './client.js'
 export { HttpRequest } from './request.js'
 export { Cookie } from './cookies.js'
 
 export function statelessClient (baseUrl: string | URL): HttpClient {
-  return client(baseUrl, fetchNetworkAdapter(), voidCookieStore())
+  return client(baseUrl, fetchNetworkAdapter())
 }
 
-export function statefulClient (baseUrl: string | URL): HttpClient {
-  return client(baseUrl, fetchNetworkAdapter(), memoryCookieStore())
+export interface StatefulHttpClient extends HttpClient {
+  setCookie: (cookie: Cookie) => void
+}
+
+export function statefulClient (baseUrl: string | URL): StatefulHttpClient {
+  const createdClient = client(baseUrl, fetchNetworkAdapter())
+
+  const store = memoryCookieStore()
+  createdClient.use(cookieMiddleware(store))
+
+  return Object.assign(createdClient, {
+    setCookie: (cookie: Cookie) => store.putCookie(cookie)
+  })
 }

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -1,0 +1,82 @@
+import { client } from '../src/client.js'
+import { Request, Response } from '../src/adapters/network-adapter.js'
+import { expect } from 'chai'
+
+describe('client.ts', function () {
+  describe('#use()', function () {
+    it('passes the request through the middleware stack', async function () {
+      const originalRequest: Request = {
+        method: 'POST',
+        headers: new Headers(),
+        url: new URL('http://localhost/'),
+        body: 'originalData'
+      }
+      const requestAfterMiddleware1: Request = {
+        ...originalRequest,
+        body: 'modified1'
+      }
+      const requestAfterMiddleware2: Request = {
+        ...originalRequest,
+        body: 'modified2'
+      }
+      let requestPassedToAdapter
+      const obj = client('http://localhost', {
+        async sendRequest (req) {
+          requestPassedToAdapter = req
+          return {
+            status: 200,
+            headers: new Headers(),
+            body: undefined
+          }
+        }
+      })
+      let requestPassedToMiddleware1
+      obj.use(async (req, next) => {
+        requestPassedToMiddleware1 = req
+        return await next(requestAfterMiddleware1)
+      })
+      let requestPassedToMiddleware2
+      obj.use(async (req, next) => {
+        requestPassedToMiddleware2 = req
+        return await next(requestAfterMiddleware2)
+      })
+      await obj.request(originalRequest.method, '/', originalRequest.body).expect(200)
+      expect(requestPassedToMiddleware1).to.deep.equal(originalRequest)
+      expect(requestPassedToMiddleware2).to.equal(requestAfterMiddleware1)
+      expect(requestPassedToAdapter).to.equal(requestAfterMiddleware2)
+    })
+
+    it('passes the response backwards through the middleware stack', async function () {
+      const adapterResponse: Response = {
+        status: 200,
+        headers: new Headers(),
+        body: 'originalResponseData'
+      }
+      const responseAfterMiddleware1: Response = {
+        ...adapterResponse,
+        body: 'modifiedResponse1'
+      }
+      const responseAfterMiddleware2: Response = {
+        ...adapterResponse,
+        body: 'modifiedResponse2'
+      }
+      const obj = client('http://localhost', {
+        sendRequest: async () => adapterResponse
+      })
+      let responseInMiddleware1
+      obj.use(async (req, next) => {
+        responseInMiddleware1 = await next(req)
+        return responseAfterMiddleware1
+      })
+      let responseInMiddleware2
+      obj.use(async (req, next) => {
+        responseInMiddleware2 = await next(req)
+        return responseAfterMiddleware2
+      })
+      const finalResponseBody = await obj.request('GET', '/').expect(200)
+      expect(responseInMiddleware2).to.equal(adapterResponse)
+      expect(responseInMiddleware1).to.equal(responseAfterMiddleware2)
+      expect(finalResponseBody).to.equal(responseAfterMiddleware1.body)
+    })
+  })
+})

--- a/test/cookies.test.ts
+++ b/test/cookies.test.ts
@@ -1,0 +1,118 @@
+import { Middleware, Response } from '../src/index.js'
+import { cookieMiddleware } from '../src/cookies.js'
+import { voidCookieStore } from '../src/stores/void-cookie-store.js'
+import { expect } from 'chai'
+import { memoryCookieStore } from '../src/stores/memory-cookie-store.js'
+
+describe('cookies.ts', function () {
+  describe('cookieMiddleware()', function () {
+    it('calls next() with unmodified request if the store has no cookies', async function () {
+      const middleware: Middleware = cookieMiddleware(voidCookieStore())
+      const expectedResponse: Response = {
+        status: 200,
+        headers: new Headers(),
+        body: 'response body'
+      }
+      const middlewareResponse = await middleware({
+        method: 'GET',
+        url: new URL('http://localhost/'),
+        headers: new Headers({
+          'X-Test-Header': 'test-header-value'
+        }),
+        body: 'hello world'
+      }, async (modified) => {
+        expect(modified.url.toString()).to.equal('http://localhost/')
+        expect(modified.method).to.equal('GET')
+        expect(modified.body).to.equal('hello world')
+        expect(Array.from(modified.headers)).to.have.deep.members([
+          ['x-test-header', 'test-header-value']
+        ])
+        return expectedResponse
+      })
+      // This implicitly ensures the middleware has called next(), otherwise it couldn't have gotten the response!
+      expect(middlewareResponse).to.equal(expectedResponse)
+    })
+
+    it('sets the Cookie header if the store has cookies', async function () {
+      const store = memoryCookieStore()
+      store.putCookie({
+        key: 'test-cookie',
+        value: 'test-cookie-value'
+      })
+      store.putCookie({
+        key: 'foo2',
+        value: 'bar'
+      })
+      const middleware: Middleware = cookieMiddleware(store)
+      const expectedResponse: Response = {
+        status: 200,
+        headers: new Headers(),
+        body: 'response body'
+      }
+      const middlewareResponse = await middleware({
+        method: 'GET',
+        url: new URL('http://localhost/'),
+        headers: new Headers({
+          'X-Test-Header': 'test-header-value'
+        }),
+        body: 'hello world'
+      }, async (modified) => {
+        expect(modified.url.toString()).to.equal('http://localhost/')
+        expect(modified.method).to.equal('GET')
+        expect(modified.body).to.equal('hello world')
+        expect(Array.from(modified.headers)).to.have.deep.members([
+          ['x-test-header', 'test-header-value'],
+          ['cookie', 'test-cookie=test-cookie-value; foo2=bar']
+        ])
+        return expectedResponse
+      })
+      // This implicitly ensures the middleware has called next(), otherwise it couldn't have gotten the response!
+      expect(middlewareResponse).to.equal(expectedResponse)
+    })
+
+    it('puts cookies from response header Set-Cookie into the store', async function () {
+      const store = memoryCookieStore()
+      const middleware: Middleware = cookieMiddleware(store)
+      const expectedResponse: Response = {
+        status: 200,
+        headers: new Headers({
+          // TODO: Change this to be valid (not comma separated, but repeated Set-Cookie) once Node supports it.
+          'set-cookie': 'cookie1=value1; Expires=Mon, 12-Jul-2022; Secure, cookie2=value2; Secure; HttpOnly, cookie3=value3'
+        }),
+        body: 'response body'
+      }
+      const middlewareResponse = await middleware({
+        method: 'GET',
+        url: new URL('http://localhost/'),
+        headers: new Headers({
+          'X-Test-Header': 'test-header-value'
+        }),
+        body: 'hello world'
+      }, async (modified) => {
+        expect(modified.url.toString()).to.equal('http://localhost/')
+        expect(modified.method).to.equal('GET')
+        expect(modified.body).to.equal('hello world')
+        expect(Array.from(modified.headers)).to.have.deep.members([
+          ['x-test-header', 'test-header-value']
+        ])
+        return expectedResponse
+      })
+      // This implicitly ensures the middleware has called next(), otherwise it couldn't have gotten the response!
+      expect(middlewareResponse).to.equal(expectedResponse)
+      expect(store.cookies).to.have.deep.members([
+        {
+          key: 'cookie1',
+          value: 'value1'
+        },
+        {
+          key: 'cookie2',
+          value: 'value2'
+        },
+        {
+          key: 'cookie3',
+          value: 'value3'
+        }
+      ])
+    })
+  })
+})


### PR DESCRIPTION
Middleware can now be added to an HttpClient. Each Middleware is simply
an async function that receives the request-to-be-sent, and can
optionally modify it before passing it further down the chain by calling
the `next()` parameter. The final middleware's call to `next()` sends
the request via the NetworkAdapter. Then, the response is passed back
down the stack and is available in each middleware by awaiting `next()`.
Again, each middleware can choose to modify the response.

Cookie sending/storing is implemented as a middleware now, decoupling
HttpClient from dealing with cookies entirely.
Another use case for middleware would be to set headers, for example.

BREAKING CHANGE: Only StatefulHttpClient offers setCookie() now.