### PR TITLE
feat: Add raw() method to HttpRequest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,10 +11,12 @@
       "devDependencies": {
         "@meyfa/eslint-config": "2.0.0",
         "@types/chai": "4.3.1",
+        "@types/chai-as-promised": "7.1.5",
         "@types/mocha": "9.1.1",
         "@types/node": "18.0.1",
         "c8": "7.11.3",
         "chai": "4.3.6",
+        "chai-as-promised": "7.1.1",
         "eslint": "8.19.0",
         "mocha": "10.0.0",
         "rimraf": "3.0.2",
@@ -207,6 +209,15 @@
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.1.tgz",
       "integrity": "sha512-/zPMqDkzSZ8t3VtxOa4KPq7uzzW978M9Tvh+j7GHKuo6k6GTLxPJ4J5gE5cjfJ26pnXst0N5Hax8Sr0T2Mi9zQ==",
       "dev": true
+    },
+    "node_modules/@types/chai-as-promised": {
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/@types/chai-as-promised/-/chai-as-promised-7.1.5.tgz",
+      "integrity": "sha512-jStwss93SITGBwt/niYrkf2C+/1KTeZCZl1LaeezTlqppAKeoQC7jxyqYuP72sxBGKCIbw7oHgbYssIRzT5FCQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/chai": "*"
+      }
     },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.4",
@@ -706,6 +717,18 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/chai-as-promised": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-7.1.1.tgz",
+      "integrity": "sha512-azL6xMoi+uxu6z4rhWQ1jbdUhOMhis2PvscD/xjLqNMkv3BPPp2JyyuTHOrf9BOosGpNQ11v6BKv/g57RXbiaA==",
+      "dev": true,
+      "dependencies": {
+        "check-error": "^1.0.2"
+      },
+      "peerDependencies": {
+        "chai": ">= 2.1.2 < 5"
       }
     },
     "node_modules/chalk": {
@@ -3619,6 +3642,15 @@
       "integrity": "sha512-/zPMqDkzSZ8t3VtxOa4KPq7uzzW978M9Tvh+j7GHKuo6k6GTLxPJ4J5gE5cjfJ26pnXst0N5Hax8Sr0T2Mi9zQ==",
       "dev": true
     },
+    "@types/chai-as-promised": {
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/@types/chai-as-promised/-/chai-as-promised-7.1.5.tgz",
+      "integrity": "sha512-jStwss93SITGBwt/niYrkf2C+/1KTeZCZl1LaeezTlqppAKeoQC7jxyqYuP72sxBGKCIbw7oHgbYssIRzT5FCQ==",
+      "dev": true,
+      "requires": {
+        "@types/chai": "*"
+      }
+    },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.4.tgz",
@@ -3956,6 +3988,15 @@
         "loupe": "^2.3.1",
         "pathval": "^1.1.1",
         "type-detect": "^4.0.5"
+      }
+    },
+    "chai-as-promised": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-7.1.1.tgz",
+      "integrity": "sha512-azL6xMoi+uxu6z4rhWQ1jbdUhOMhis2PvscD/xjLqNMkv3BPPp2JyyuTHOrf9BOosGpNQ11v6BKv/g57RXbiaA==",
+      "dev": true,
+      "requires": {
+        "check-error": "^1.0.2"
       }
     },
     "chalk": {

--- a/package.json
+++ b/package.json
@@ -40,10 +40,12 @@
   "devDependencies": {
     "@meyfa/eslint-config": "2.0.0",
     "@types/chai": "4.3.1",
+    "@types/chai-as-promised": "7.1.5",
     "@types/mocha": "9.1.1",
     "@types/node": "18.0.1",
     "c8": "7.11.3",
     "chai": "4.3.6",
+    "chai-as-promised": "7.1.1",
     "eslint": "8.19.0",
     "mocha": "10.0.0",
     "rimraf": "3.0.2",

--- a/src/adapters/network-adapter.ts
+++ b/src/adapters/network-adapter.ts
@@ -8,10 +8,10 @@ export interface Request {
   headers: Headers
 }
 
-export interface Response {
+export interface Response<Body = unknown> {
   status: number
   headers: Headers
-  body: unknown
+  body: Body
 }
 
 export interface NetworkAdapter {

--- a/src/request.ts
+++ b/src/request.ts
@@ -3,6 +3,7 @@ import { assertStatus } from './assertions.js'
 
 export interface HttpRequest<ResponseType = any> {
   expect: (status: number) => Promise<ResponseType>
+  raw: () => Promise<Response<ResponseType>>
 }
 
 export function requestFromAsync<ResponseType> (getResponse: () => PromiseLike<Response>): HttpRequest<ResponseType> {
@@ -12,6 +13,10 @@ export function requestFromAsync<ResponseType> (getResponse: () => PromiseLike<R
       assertStatus(response, statusNumber)
       // We have absolutely no type safety here!
       return response.body as any
+    },
+
+    async raw () {
+      return (await getResponse()) as Response<ResponseType>
     }
   }
 }

--- a/test/request.test.ts
+++ b/test/request.test.ts
@@ -1,0 +1,43 @@
+import { requestFromAsync } from '../src/request.js'
+import chai, { expect } from 'chai'
+import chaiAsPromised from 'chai-as-promised'
+
+chai.use(chaiAsPromised)
+
+describe('request.ts', function () {
+  describe('#expect()', function () {
+    it('returns the response body', async function () {
+      const obj = requestFromAsync(async () => {
+        return {
+          status: 200,
+          headers: new Headers(),
+          body: 'hello world'
+        }
+      })
+      await expect(obj.expect(200)).to.eventually.equal('hello world')
+    })
+
+    it('fails if status does not match expected', async function () {
+      const obj = requestFromAsync(async () => {
+        return {
+          status: 200,
+          headers: new Headers(),
+          body: 'hello world'
+        }
+      })
+      await expect(obj.expect(201)).to.eventually.be.rejected
+    })
+  })
+
+  describe('#raw()', function () {
+    it('returns the response as-is', async function () {
+      const response = {
+        status: 200,
+        headers: new Headers(),
+        body: 'hello world'
+      }
+      const obj = requestFromAsync(async () => response)
+      await expect(obj.raw()).to.eventually.equal(response)
+    })
+  })
+})


### PR DESCRIPTION
This allows obtaining the entire response, including headers, in its
raw form and without any assertions.