### PR TITLE
feat: Support awaiting a request directly

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -27,14 +27,12 @@ async function processMiddleware (adapter: NetworkAdapter, request: Request, mid
 export function client (baseUrl: string | URL, adapter: NetworkAdapter): HttpClient {
   const middlewareStack: Middleware[] = []
 
-  const request: HttpClient['request'] = (verb, path, data) => requestFromAsync(async () => {
-    return await processMiddleware(adapter, {
-      url: new URL(path, baseUrl),
-      method: verb,
-      body: data,
-      headers: new Headers()
-    }, middlewareStack)
-  })
+  const request: HttpClient['request'] = (verb, path, data) => requestFromAsync(processMiddleware(adapter, {
+    url: new URL(path, baseUrl),
+    method: verb,
+    body: data,
+    headers: new Headers()
+  }, middlewareStack))
 
   return {
     request,

--- a/src/request.ts
+++ b/src/request.ts
@@ -1,22 +1,26 @@
 import { Response } from './adapters/network-adapter.js'
 import { assertStatus } from './assertions.js'
 
-export interface HttpRequest<ResponseType = any> {
+export interface HttpRequest<ResponseType = any> extends PromiseLike<Response<ResponseType>> {
   expect: (status: number) => Promise<ResponseType>
   raw: () => Promise<Response<ResponseType>>
 }
 
-export function requestFromAsync<ResponseType> (getResponse: () => PromiseLike<Response>): HttpRequest<ResponseType> {
+export function requestFromAsync<ResponseType> (responsePromise: PromiseLike<Response>): HttpRequest<ResponseType> {
+  const untypedResponsePromise = responsePromise as PromiseLike<Response<ResponseType>>
+
   return {
+    then: (...args) => untypedResponsePromise.then(...args),
+
     async expect (statusNumber) {
-      const response = await getResponse()
+      const response = await untypedResponsePromise
       assertStatus(response, statusNumber)
       // We have absolutely no type safety here!
-      return response.body as any
+      return response.body
     },
 
     async raw () {
-      return (await getResponse()) as Response<ResponseType>
+      return await untypedResponsePromise
     }
   }
 }

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -40,7 +40,7 @@ describe('client.ts', function () {
         requestPassedToMiddleware2 = req
         return await next(requestAfterMiddleware2)
       })
-      await obj.request(originalRequest.method, '/', originalRequest.body).raw()
+      await obj.request(originalRequest.method, '/', originalRequest.body)
       expect(requestPassedToMiddleware1).to.deep.equal(originalRequest)
       expect(requestPassedToMiddleware2).to.equal(requestAfterMiddleware1)
       expect(requestPassedToAdapter).to.equal(requestAfterMiddleware2)
@@ -73,7 +73,7 @@ describe('client.ts', function () {
         responseInMiddleware2 = await next(req)
         return responseAfterMiddleware2
       })
-      const finalResponse = await obj.request('GET', '/').raw()
+      const finalResponse = await obj.request('GET', '/')
       expect(responseInMiddleware2).to.equal(adapterResponse)
       expect(responseInMiddleware1).to.equal(responseAfterMiddleware2)
       expect(finalResponse).to.equal(responseAfterMiddleware1)

--- a/test/request.test.ts
+++ b/test/request.test.ts
@@ -5,27 +5,48 @@ import chaiAsPromised from 'chai-as-promised'
 chai.use(chaiAsPromised)
 
 describe('request.ts', function () {
+  it('can be awaited to obtain the response object', async function () {
+    const response = {
+      status: 200,
+      headers: new Headers(),
+      body: 'hello world'
+    }
+    const obj = requestFromAsync(Promise.resolve(response))
+    const awaitedResponse = await obj
+    expect(awaitedResponse).to.equal(response)
+  })
+
+  it('rejects if the input promise rejects', async function () {
+    const rejected = Promise.reject(new Error('test reject'))
+    await expect(requestFromAsync(rejected)).to.eventually.be.rejectedWith('test reject')
+    const rejectSoon = new Promise<any>((resolve, reject) => setTimeout(() => reject(new Error('test reject')), 50))
+    await expect(requestFromAsync(rejectSoon)).to.eventually.be.rejectedWith('test reject')
+  })
+
   describe('#expect()', function () {
     it('returns the response body', async function () {
-      const obj = requestFromAsync(async () => {
-        return {
-          status: 200,
-          headers: new Headers(),
-          body: 'hello world'
-        }
-      })
+      const obj = requestFromAsync(Promise.resolve({
+        status: 200,
+        headers: new Headers(),
+        body: 'hello world'
+      }))
       await expect(obj.expect(200)).to.eventually.equal('hello world')
     })
 
     it('fails if status does not match expected', async function () {
-      const obj = requestFromAsync(async () => {
-        return {
-          status: 200,
-          headers: new Headers(),
-          body: 'hello world'
-        }
-      })
+      const obj = requestFromAsync(Promise.resolve({
+        status: 200,
+        headers: new Headers(),
+        body: 'hello world'
+      }))
       await expect(obj.expect(201)).to.eventually.be.rejected
+    })
+
+    it('rejects if the input promise rejects', async function () {
+      const rejected = Promise.reject(new Error('test reject'))
+      await expect(requestFromAsync(rejected).expect(200)).to.eventually.be.rejectedWith('test reject')
+      const rejectSoon = new Promise<any>((resolve, reject) => setTimeout(() => reject(new Error('test reject')), 50))
+      await expect(requestFromAsync(rejectSoon).expect(200)).to.eventually.be.rejectedWith('test reject')
     })
   })
 
@@ -36,8 +57,15 @@ describe('request.ts', function () {
         headers: new Headers(),
         body: 'hello world'
       }
-      const obj = requestFromAsync(async () => response)
+      const obj = requestFromAsync(Promise.resolve(response))
       await expect(obj.raw()).to.eventually.equal(response)
+    })
+
+    it('rejects if the input promise rejects', async function () {
+      const rejected = Promise.reject(new Error('test reject'))
+      await expect(requestFromAsync(rejected).raw()).to.eventually.be.rejectedWith('test reject')
+      const rejectSoon = new Promise<any>((resolve, reject) => setTimeout(() => reject(new Error('test reject')), 50))
+      await expect(requestFromAsync(rejectSoon).raw()).to.eventually.be.rejectedWith('test reject')
     })
   })
 })


### PR DESCRIPTION
Through this patch, doing `await client.get('/foo')` becomes possible.
It behaves just like `await client.get('/foo').raw()` would. Supporting
this pattern avoids pitfalls for users of this library without any real
downsides.