### PR TITLE
chore: Remove rimraf dev dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
         "c8": "7.12.0",
         "eslint": "8.35.0",
         "mocha": "10.2.0",
-        "rimraf": "4.1.1",
         "ts-node": "10.9.1",
         "typescript": "4.9.5",
         "undici": "5.20.0"
@@ -2985,21 +2984,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/rimraf": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-4.1.1.tgz",
-      "integrity": "sha512-Z4Y81w8atcvaJuJuBB88VpADRH66okZAuEm+Jtaufa+s7rZmIz+Hik2G53kGaNytE7lsfXyWktTmfVz0H9xuDg==",
-      "dev": true,
-      "bin": {
-        "rimraf": "dist/cjs/src/bin.js"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -5704,12 +5688,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
       "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
-      "dev": true
-    },
-    "rimraf": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-4.1.1.tgz",
-      "integrity": "sha512-Z4Y81w8atcvaJuJuBB88VpADRH66okZAuEm+Jtaufa+s7rZmIz+Hik2G53kGaNytE7lsfXyWktTmfVz0H9xuDg==",
       "dev": true
     },
     "run-parallel": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "rimraf dist && tsc",
+    "build": "node -e \"fs.rmSync('./dist',{force:true,recursive:true})\" && tsc",
     "lint": "tsc --noEmit -p tsconfig.lint.json && eslint --ignore-path .gitignore .",
     "lint-fix": "tsc --noEmit -p tsconfig.lint.json && eslint --fix --ignore-path .gitignore .",
     "test": "mocha --recursive \"test/**/*.test.*\"",
@@ -44,7 +44,6 @@
     "c8": "7.12.0",
     "eslint": "8.35.0",
     "mocha": "10.2.0",
-    "rimraf": "4.1.1",
     "ts-node": "10.9.1",
     "typescript": "4.9.5",
     "undici": "5.20.0"


### PR DESCRIPTION
Since we depend on Node.js anyway, we can use its CLI to remove the dist directory, without having to depend on a 3rd-party package.