### PR TITLE
chore: Configure release-please with 'bump-minor-pre-major' option

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,6 +13,7 @@ jobs:
         id: release
         with:
           release-type: node
+          bump-minor-pre-major: true
       - uses: actions/checkout@v3
         if: ${{ steps.release.outputs.release_created }}
       - uses: actions/setup-node@v3


### PR DESCRIPTION
This makes it so breaking changes don't force a v1.0.0 release. The v1.0.0 release can be triggered manually with the "Release-As" commit footer.