### PR TITLE
feat: Parse "Expires" cookie attribute

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,10 +8,14 @@
       "name": "get-some-rest",
       "version": "0.4.0",
       "license": "MIT",
+      "dependencies": {
+        "set-cookie-parser": "2.6.0"
+      },
       "devDependencies": {
         "@meyfa/eslint-config": "3.0.0",
         "@types/mocha": "10.0.1",
         "@types/node": "18.15.3",
+        "@types/set-cookie-parser": "2.4.2",
         "c8": "7.12.0",
         "eslint": "8.35.0",
         "mocha": "10.2.0",
@@ -260,6 +264,15 @@
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz",
       "integrity": "sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==",
       "dev": true
+    },
+    "node_modules/@types/set-cookie-parser": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@types/set-cookie-parser/-/set-cookie-parser-2.4.2.tgz",
+      "integrity": "sha512-fBZgytwhYAUkj/jC/FAV4RQ5EerRup1YQsXQCh8rZfiHkc4UahC192oH0smGwsXol3cL3A5oETuAHeQHmhXM4w==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "5.47.1",
@@ -3051,6 +3064,11 @@
         "randombytes": "^2.1.0"
       }
     },
+    "node_modules/set-cookie-parser": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.6.0.tgz",
+      "integrity": "sha512-RVnVQxTXuerk653XfuliOxBP81Sf0+qfQE73LIYKcyMYHG94AuH0kgrQpRDuTZnSmjpysHmzxJXKNfa6PjFhyQ=="
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -3772,6 +3790,15 @@
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz",
       "integrity": "sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==",
       "dev": true
+    },
+    "@types/set-cookie-parser": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@types/set-cookie-parser/-/set-cookie-parser-2.4.2.tgz",
+      "integrity": "sha512-fBZgytwhYAUkj/jC/FAV4RQ5EerRup1YQsXQCh8rZfiHkc4UahC192oH0smGwsXol3cL3A5oETuAHeQHmhXM4w==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@typescript-eslint/eslint-plugin": {
       "version": "5.47.1",
@@ -5722,6 +5749,11 @@
       "requires": {
         "randombytes": "^2.1.0"
       }
+    },
+    "set-cookie-parser": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.6.0.tgz",
+      "integrity": "sha512-RVnVQxTXuerk653XfuliOxBP81Sf0+qfQE73LIYKcyMYHG94AuH0kgrQpRDuTZnSmjpysHmzxJXKNfa6PjFhyQ=="
     },
     "shebang-command": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -41,11 +41,15 @@
     "@meyfa/eslint-config": "3.0.0",
     "@types/mocha": "10.0.1",
     "@types/node": "18.15.3",
+    "@types/set-cookie-parser": "2.4.2",
     "c8": "7.12.0",
     "eslint": "8.35.0",
     "mocha": "10.2.0",
     "ts-node": "10.9.1",
     "typescript": "5.0.2",
     "undici": "5.21.0"
+  },
+  "dependencies": {
+    "set-cookie-parser": "2.6.0"
   }
 }

--- a/src/stores/memory-cookie-store.ts
+++ b/src/stores/memory-cookie-store.ts
@@ -2,10 +2,14 @@ import { Cookie } from '../cookies.js'
 import { CookieStore } from './cookie-store.js'
 
 export function memoryCookieStore (): CookieStore {
-  const cookies: Cookie[] = []
+  let cookies: Cookie[] = []
 
   return {
-    cookies,
+    get cookies () {
+      const now = new Date()
+      cookies = cookies.filter(c => c.expires == null || c.expires >= now)
+      return cookies
+    },
     putCookie (cookie) {
       const existing = cookies.findIndex(c => c.key === cookie.key)
       if (existing >= 0) {

--- a/test/cookies.test.ts
+++ b/test/cookies.test.ts
@@ -6,6 +6,8 @@ import { memoryCookieStore } from '../src/stores/memory-cookie-store.js'
 
 describe('cookies.ts', function () {
   describe('cookieMiddleware()', function () {
+    const nextYear = new Date().getFullYear() + 1
+
     it('calls next() with unmodified request if the store has no cookies', async function () {
       const middleware: Middleware = cookieMiddleware(voidCookieStore())
       const expectedResponse: Response = {
@@ -76,7 +78,7 @@ describe('cookies.ts', function () {
       const expectedResponse: Response = {
         status: 200,
         headers: new Headers([
-          ['set-cookie', 'cookie1=value1; Expires=Mon, 12-Jul-2022; Secure'],
+          ['set-cookie', `cookie1=value1; Expires=Mon, 12-Jul-${nextYear}; Secure`],
           ['set-cookie', 'cookie2=value2; Secure; HttpOnly'],
           ['set-cookie', 'cookie3=value3']
         ]),
@@ -103,15 +105,18 @@ describe('cookies.ts', function () {
       assert.deepStrictEqual(store.cookies, [
         {
           key: 'cookie1',
-          value: 'value1'
+          value: 'value1',
+          expires: new Date(nextYear, 6, 12)
         },
         {
           key: 'cookie2',
-          value: 'value2'
+          value: 'value2',
+          expires: undefined
         },
         {
           key: 'cookie3',
-          value: 'value3'
+          value: 'value3',
+          expires: undefined
         }
       ])
     })

--- a/test/stores/memory-cookie-store.test.ts
+++ b/test/stores/memory-cookie-store.test.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert'
 import { memoryCookieStore } from '../../src/stores/memory-cookie-store.js'
 import { Cookie } from '../../src/index.js'
+import { setTimeout } from 'node:timers/promises'
 
 describe('stores/memory-cookie-store.ts', function () {
   it('initially returns empty cookies array', function () {
@@ -38,5 +39,25 @@ describe('stores/memory-cookie-store.ts', function () {
     }
     store.putCookie(cookie2)
     assert.deepStrictEqual(store.cookies, [cookie2])
+  })
+
+  it('removes cookies when expires is in the past', function () {
+    const store = memoryCookieStore()
+    store.putCookie({ key: 'foo', value: 'bar' })
+    store.putCookie({ key: 'foo', value: 'baz', expires: new Date(0) })
+    assert.deepStrictEqual(store.cookies, [])
+  })
+
+  it('does not return cookies that have expired', async function () {
+    const store = memoryCookieStore()
+    const cookie = {
+      key: 'foo',
+      value: 'bar',
+      expires: new Date(Date.now() + 50)
+    }
+    store.putCookie(cookie)
+    assert.deepStrictEqual(store.cookies, [cookie])
+    await setTimeout(100)
+    assert.deepStrictEqual(store.cookies, [])
   })
 })


### PR DESCRIPTION
This adds a dependency on "set-cookie-parser", which does the heavy lifting of cookie parsing. I thought about implementing this myself, but it's simply not worth it. For now, our memory cookie store makes use of the "expires" attribute so that cookies have a maximum lifetime, and can also be deleted by the server by setting "expires" to a past date.