### PR TITLE
chore: Add tsconfig.json to "test" directory

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 Fabian Meyer
+Copyright (c) 2022 - 2023 Fabian Meyer
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../tsconfig.lint.json"
+}


### PR DESCRIPTION
The TSConfig lookup in IntelliJ IDEA is broken and won't use the `tsconfig.lint.json` any more. By adding an explicit `tsconfig.json` to the test directory, we avoid TS errors in the IDE.