### PR TITLE
fix: Call `encodeURIComponent` on cookie value for request

### DIFF
--- a/src/cookies.ts
+++ b/src/cookies.ts
@@ -11,8 +11,7 @@ export interface Cookie {
 export function cookieMiddleware (store: CookieStore): Middleware {
   return async (req, next) => {
     for (const { key, value } of store.cookies) {
-      // TODO: Properly escape this stuff.
-      req.headers.append('cookie', `${key}=${value}`)
+      req.headers.append('cookie', `${key}=${encodeURIComponent(value)}`)
     }
     const res = await next(req)
     parseCookies(res.headers).forEach((cookie) => store.putCookie(cookie))

--- a/test/cookies.test.ts
+++ b/test/cookies.test.ts
@@ -120,5 +120,64 @@ describe('cookies.ts', function () {
         }
       ])
     })
+
+    it('unescapes cookies from response', async function () {
+      const store = memoryCookieStore()
+      const middleware: Middleware = cookieMiddleware(store)
+      const expectedResponse: Response = {
+        status: 200,
+        headers: new Headers([
+          ['set-cookie', 'session=kKw1VBLHevj5xGLYOdibAhJo4SIEAZAUrJdyA6mu0dwfE3hQm2mhCE%2FqZuasAspj0SeeueDjfFqmixNHtFcfKquJkJ6vrYL1WGVKdUisSHspDedug98E6e919nxAaQ%3D%3D%3BDij%2FTbm9SGHOyjb%2B9Dhyj%2Fiev9p%2B2Lkm']
+        ]),
+        body: 'response body'
+      }
+      const middlewareResponse = await middleware({
+        method: 'GET',
+        url: new URL('http://localhost/'),
+        headers: new Headers(),
+        body: 'hello world'
+      }, async (modified) => {
+        assert.strictEqual(modified.url.toString(), 'http://localhost/')
+        assert.strictEqual(modified.method, 'GET')
+        return expectedResponse
+      })
+      // This implicitly ensures the middleware has called next(), otherwise it couldn't have gotten the response!
+      assert.strictEqual(middlewareResponse, expectedResponse)
+      assert.deepStrictEqual(store.cookies, [
+        {
+          key: 'session',
+          value: 'kKw1VBLHevj5xGLYOdibAhJo4SIEAZAUrJdyA6mu0dwfE3hQm2mhCE/qZuasAspj0SeeueDjfFqmixNHtFcfKquJkJ6vrYL1WGVKdUisSHspDedug98E6e919nxAaQ==;Dij/Tbm9SGHOyjb+9Dhyj/iev9p+2Lkm',
+          expires: undefined
+        }
+      ])
+    })
+
+    it('escapes cookie values for request', async function () {
+      const store = memoryCookieStore()
+      store.putCookie({
+        key: 'session',
+        value: 'kKw1VBLHevj5xGLYOdibAhJo4SIEAZAUrJdyA6mu0dwfE3hQm2mhCE/qZuasAspj0SeeueDjfFqmixNHtFcfKquJkJ6vrYL1WGVKdUisSHspDedug98E6e919nxAaQ==;Dij/Tbm9SGHOyjb+9Dhyj/iev9p+2Lkm'
+      })
+      const middleware: Middleware = cookieMiddleware(store)
+      const expectedResponse: Response = {
+        status: 200,
+        headers: new Headers(),
+        body: 'response body'
+      }
+      const middlewareResponse = await middleware({
+        method: 'GET',
+        url: new URL('http://localhost/'),
+        headers: new Headers()
+      }, async (modified) => {
+        assert.strictEqual(modified.url.toString(), 'http://localhost/')
+        assert.strictEqual(modified.method, 'GET')
+        assert.deepStrictEqual(Array.from(modified.headers), [
+          ['cookie', 'session=kKw1VBLHevj5xGLYOdibAhJo4SIEAZAUrJdyA6mu0dwfE3hQm2mhCE%2FqZuasAspj0SeeueDjfFqmixNHtFcfKquJkJ6vrYL1WGVKdUisSHspDedug98E6e919nxAaQ%3D%3D%3BDij%2FTbm9SGHOyjb%2B9Dhyj%2Fiev9p%2B2Lkm']
+        ])
+        return expectedResponse
+      })
+      // This implicitly ensures the middleware has called next(), otherwise it couldn't have gotten the response!
+      assert.strictEqual(middlewareResponse, expectedResponse)
+    })
   })
 })

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,1 +1,0 @@
-// TODO write tests


### PR DESCRIPTION
The internal cookie parser was already decoding the cookie value before placing it into the store. However, when making a subsequent request, we did not encode the value again. This could result in servers rejecting the value, as it did not match the one provided by the server.